### PR TITLE
Fix unable to parse query { $ne: null }

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -28,7 +28,6 @@ QueryCompiler.prototype._compilePredicates = function (query) {
   }
   _.forEach(function (key) {
     filters = filters.concat(self._compilePart(key, query[key]));
-
   })(keys);
   return filters;
 };
@@ -127,6 +126,7 @@ QueryCompiler.prototype._compilePart = function (key, queryPart) {
     case 'Number':
     case 'Boolean':
     case 'String':
+    case 'Null':
       filters.push(hi.check(key, _.eq(queryPart)));
       break;
     default:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuery",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -1,5 +1,18 @@
-var QueryCompiler = require('../lib/compiler'); 
+var should = require('should');
+
+var QueryCompiler = require('../lib/compiler');
 describe('QueryCompiler', function () {
+  describe.only('compile', function () {
+    it('compile ne null query', function () {
+      var query = {
+        attachmentId: { $ne: null }
+      };
+      var compiler = new QueryCompiler();
+      should.doesNotThrow(function () {
+        compiler.compile(query);
+      });
+    });
+  });
   describe('_compilePredicates', function () {
     it('compile eq query', function () {
       var compiler = new QueryCompiler();

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -2,7 +2,7 @@ var should = require('should');
 
 var QueryCompiler = require('../lib/compiler');
 describe('QueryCompiler', function () {
-  describe.only('compile', function () {
+  describe('compile', function () {
     it('compile ne null query', function () {
       var query = {
         attachmentId: { $ne: null }


### PR DESCRIPTION
## Query

```ts
{
    attachmentId: {
        $exists: true,
        $ne: null
    },
    _id: {
        $in: [
            "9a15547b-4464-439f-baba-edeb41731656"
        ]
    }
}
```

## Error

```shell
Caught global exception: Error: Unable to parse query + attachmentId | null
    at QueryCompiler._compilePart (C:\Dev\lynx\lx-api-server\node_modules\viewdb_persistence_store_mongodb\node_modules\kuery\lib\compiler.js:135:13)
    at QueryCompiler._compilePart (C:\Dev\lynx\lx-api-server\node_modules\viewdb_persistence_store_mongodb\node_modules\kuery\lib\compiler.js:66:40)
    at C:\Dev\lynx\lx-api-server\node_modules\viewdb_persistence_store_mongodb\node_modules\kuery\lib\compiler.js:31:35
    at r (C:\Dev\lynx\lx-api-server\node_modules\lodash\lodash.min.js:9:347)
    at _f (C:\Dev\lynx\lx-api-server\node_modules\lodash\lodash.min.js:84:352)
    at l (C:\Dev\lynx\lx-api-server\node_modules\lodash\lodash.min.js:58:213)
    at QueryCompiler._compilePredicates (C:\Dev\lynx\lx-api-server\node_modules\viewdb_persistence_store_mongodb\node_modules\kuery\lib\compiler.js:33:5)
    at QueryCompiler.compile (C:\Dev\lynx\lx-api-server\node_modules\viewdb_persistence_store_mongodb\node_modules\kuery\lib\compiler.js:9:22)
    at new Kuery (C:\Dev\lynx\lx-api-server\node_modules\viewdb_persistence_store_mongodb\node_modules\kuery\lib\kuery.js:6:45)
    at Observer._checkKuery (C:\Dev\lynx\lx-api-server\node_modules\viewdb_persistence_store_mongodb\lib\observe.js:96:11)
    at Observer._onUpdate (C:\Dev\lynx\lx-api-server\node_modules\viewdb_persistence_store_mongodb\lib\observe.js:117:20)
    at Observer._onOperation (C:\Dev\lynx\lx-api-server\node_modules\viewdb_persistence_store_mongodb\lib\observe.js:84:12)
    at C:\Dev\lynx\lx-api-server\node_modules\viewdb_persistence_store_mongodb\lib\oplog_listener.js:90:32
    at arrayEach (C:\Dev\lynx\lx-api-server\node_modules\lodash\lodash.js:530:11)
    at Function.forEach (C:\Dev\lynx\lx-api-server\node_modules\lodash\lodash.js:9410:14)
    at C:\Dev\lynx\lx-api-server\node_modules\viewdb_persistence_store_mongodb\lib\oplog_listener.js:89:11
    at handleCallback (C:\Dev\lynx\lx-api-server\node_modules\mongodb\lib\utils.js:120:56)
    at C:\Dev\lynx\lx-api-server\node_modules\mongodb\lib\cursor.js:860:16
    at handleCallback (C:\Dev\lynx\lx-api-server\node_modules\mongodb-core\lib\cursor.js:171:5)
    at setCursorDeadAndNotified (C:\Dev\lynx\lx-api-server\node_modules\mongodb-core\lib\cursor.js:505:3)
    at nextFunction (C:\Dev\lynx\lx-api-server\node_modules\mongodb-core\lib\cursor.js:651:7)
    at Cursor.next [as _next] (C:\Dev\lynx\lx-api-server\node_modules\mongodb-core\lib\cursor.js:692:3)
    at fetchDocs (C:\Dev\lynx\lx-api-server\node_modules\mongodb\lib\cursor.js:856:10)
    at C:\Dev\lynx\lx-api-server\node_modules\mongodb\lib\cursor.js:879:7
    at handleCallback (C:\Dev\lynx\lx-api-server\node_modules\mongodb-core\lib\cursor.js:171:5)
    at nextFunction (C:\Dev\lynx\lx-api-server\node_modules\mongodb-core\lib\cursor.js:682:5)
    at C:\Dev\lynx\lx-api-server\node_modules\mongodb-core\lib\cursor.js:593:7
    at queryCallback (C:\Dev\lynx\lx-api-server\node_modules\mongodb-core\lib\cursor.js:232:18)
    at C:\Dev\lynx\lx-api-server\node_modules\mongodb-core\lib\connection\pool.js:469:18
    at processTicksAndRejections (internal/process/task_queues.js:79:11)
```