### PR TITLE
Fix $nin should match checking nested properties of null object

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -66,7 +66,7 @@ QueryCompiler.prototype._compilePart = function (key, queryPart) {
             filters.push(hi.compare(key, _.includes, op));
             break;
           case '$nin':
-            filters.push(hi.compare(key, excludes, op, true));
+            filters.push(_.negate(hi.compare(key, _.includes, op)));
             break;
           case '$regex':
             filters.push(

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -38,12 +38,6 @@ function getType(val) {
   return type.substr(0, type.length - 1);
 }
 
-function excludes(fp, excluded) {
-  return function (candidate) {
-    return !_.includes(candidate, excluded)
-  }
-}
-
 QueryCompiler.prototype._compilePart = function (key, queryPart) {
   var op;
   var queryPartType = null;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -66,7 +66,7 @@ QueryCompiler.prototype._compilePart = function (key, queryPart) {
             filters.push(hi.compare(key, _.includes, op));
             break;
           case '$nin':
-            filters.push(hi.compare(key, excludes, op));
+            filters.push(hi.compare(key, excludes, op, true));
             break;
           case '$regex':
             filters.push(

--- a/lib/hidash.js
+++ b/lib/hidash.js
@@ -34,11 +34,12 @@ var hi = {
       return true;
     };
   },
-  check: function check(key, op) {
+  check: function check(key, op, returnValueForNoCandidates) {
     var res;
     if (key.indexOf('.') !== -1) {
       res = function (v) {
-        return _.some(op)(hi.collect(key)(v));
+        var candidates = hi.collect(key)(v);
+        return candidates.length === 0 ? returnValueForNoCandidates : _.some(op)(candidates);
       };
     } else {
       res = function (v) {
@@ -47,8 +48,8 @@ var hi = {
     }
     return res;
   },
-  compare: function COMP(key, op, arg) {
-    return hi.check(key, op(_, arg));
+  compare: function COMP(key, op, arg, returnValueForNoCandidates) {
+    return hi.check(key, op(_, arg), returnValueForNoCandidates || false);
   },
   exists: function exists(key, op) {
     return hi.check(key, function (v) {

--- a/lib/hidash.js
+++ b/lib/hidash.js
@@ -34,12 +34,11 @@ var hi = {
       return true;
     };
   },
-  check: function check(key, op, returnValueForNoCandidates) {
+  check: function check(key, op) {
     var res;
     if (key.indexOf('.') !== -1) {
       res = function (v) {
-        var candidates = hi.collect(key)(v);
-        return candidates.length === 0 ? returnValueForNoCandidates : _.some(op)(candidates);
+        return _.some(op)(hi.collect(key)(v));
       };
     } else {
       res = function (v) {
@@ -48,8 +47,8 @@ var hi = {
     }
     return res;
   },
-  compare: function COMP(key, op, arg, returnValueForNoCandidates) {
-    return hi.check(key, op(_, arg), returnValueForNoCandidates || false);
+  compare: function COMP(key, op, arg) {
+    return hi.check(key, op(_, arg));
   },
   exists: function exists(key, op) {
     return hi.check(key, function (v) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuery",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/test/kuery.js
+++ b/test/kuery.js
@@ -11,6 +11,10 @@ var collection = [
   { id: 5, name: 'PG', girlfriends: [{ name: 'Hanna', hotness: 200 }], born: new Date('1989-01-01T12:00:00.000Z') }
 ];
 
+var collectionWithNull = [
+  { id: 6, name: 'KE', girlfriends: null }
+];
+
 describe('Kuery', function () {
   it('should return 0 for empty collection', function () {
     var q = new Kuery({});
@@ -73,6 +77,34 @@ describe('Kuery', function () {
   it('should return correct elements for composite query', function () {
     var q = new Kuery({ name: { $nin: ['Andreas', 'Emil'] }, id: 1 });
     q.find(collection).length.should.equal(0);
+  });
+  it('should match when object is null and nested property is checked with $nin', function () {
+    var q = new Kuery({
+      name: 'KE',
+      'girlfriends.wife': { $nin: ['Shin Hye-sun'] }
+    });
+    q.find(collectionWithNull).length.should.equal(1);
+  });
+  it('should match when object is null and nested property is checked with $ne', function () {
+    var q = new Kuery({
+      name: 'KE',
+      'girlfriends.wife': { $ne: 'value' }
+    });
+    q.find(collectionWithNull).length.should.equal(1);
+  });
+  it('should not match when object is null and nested property is checked with $in', function () {
+    var q = new Kuery({
+      name: 'KE',
+      'girlfriends.wife': { $in: ['value'] }
+    });
+    q.find(collectionWithNull).length.should.equal(0);
+  });
+  it('should not match when object is null and nested property is checked with $eq', function () {
+    var q = new Kuery({
+      name: 'KE',
+      'girlfriends.wife': { $eq: 'value' }
+    });
+    q.find(collectionWithNull).length.should.equal(0);
   });
   it('should return correct elements for regex string query', function () {
     var q = new Kuery({ name: { $regex: 'Andr.*', $options: 'i' } });

--- a/test/kuery.js
+++ b/test/kuery.js
@@ -88,21 +88,21 @@ describe('Kuery', function () {
   it('should match when object is null and nested property is checked with $ne', function () {
     var q = new Kuery({
       name: 'KE',
-      'girlfriends.wife': { $ne: 'value' }
+      'girlfriends.wife': { $ne: 'Shin Hye-sun' }
     });
     q.find(collectionWithNull).length.should.equal(1);
   });
   it('should not match when object is null and nested property is checked with $in', function () {
     var q = new Kuery({
       name: 'KE',
-      'girlfriends.wife': { $in: ['value'] }
+      'girlfriends.wife': { $in: ['Shin Hye-sun'] }
     });
     q.find(collectionWithNull).length.should.equal(0);
   });
   it('should not match when object is null and nested property is checked with $eq', function () {
     var q = new Kuery({
       name: 'KE',
-      'girlfriends.wife': { $eq: 'value' }
+      'girlfriends.wife': { $eq: 'Shin Hye-sun' }
     });
     q.find(collectionWithNull).length.should.equal(0);
   });

--- a/test/kuery.js
+++ b/test/kuery.js
@@ -46,6 +46,10 @@ describe('Kuery', function () {
     var q = new Kuery({ id: { $nin: [1, 2] } });
     q.find(collection).length.should.equal(3);
   });
+  it('should return all elements for property with empty $nin query', function () {
+    var q = new Kuery({ id: { $nin: [] } });
+    q.find(collection).length.should.equal(5);
+  });
   it('should return correct elements for property with path eq query', function () {
     var q = new Kuery({ 'address.street': 'Bellmansgatan' });
     q.find(collection).length.should.equal(1);


### PR DESCRIPTION
Makes checking that a nested property of a null property excludes provided values.

So this data would match when checking `{ 'prop.nested.property': { $nin: ['value'] } }`
```json
{
  "prop": null
}
```